### PR TITLE
Fix Prettier config for Windows (#771)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "prettier": {
     "semi": true,
     "singleQuote": true,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "endOfLine": "auto"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
According to Prettier's documentation, `auto` was supposed to be the default value for `endOfLine`, but apparently it's not.